### PR TITLE
update isort so lint will pass

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ files: simularium_metrics_calculator
 repos:
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.13.2
     hooks:
       - id: isort
 


### PR DESCRIPTION
Problem
=======
The CI build is failing because `just lint` is failing. I traced it back and determined that updating the version of `isort` would fix it.
